### PR TITLE
Fix logout session handling

### DIFF
--- a/mamp_demo/logout.php
+++ b/mamp_demo/logout.php
@@ -1,5 +1,6 @@
 <?php
-	$_SESSION=[];
+        session_start();
+        $_SESSION=[];
 	if(ini_get("session.use_cookies"))
 	{
 		$param = session_get_cookie_params();


### PR DESCRIPTION
## Summary
- ensure session is started before modifying `$_SESSION` in `logout.php`

## Testing
- `php -l mamp_demo/logout.php`
- ran a logout test script verifying session contents were cleared

------
https://chatgpt.com/codex/tasks/task_e_688638fd2d44832681a0ecf63df2fe52