### PR TITLE
Fix CSS height calc spacing

### DIFF
--- a/mamp_demo/dashboard.php
+++ b/mamp_demo/dashboard.php
@@ -83,7 +83,7 @@
             }
             #graph
             {
-                height: calc(100vh-30px);
+                height: calc(100vh - 30px);
             }
         </style>
 </head>


### PR DESCRIPTION
## Summary
- fix CSS calc expression spacing in `dashboard.php`

## Testing
- `php -l mamp_demo/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688638f8d1fc8326b4add0c029fa9ab4