### PR TITLE
Add relationship request workflow

### DIFF
--- a/mamp_demo/config.php
+++ b/mamp_demo/config.php
@@ -28,14 +28,24 @@
 				password_hash VARCHAR(255) NOT NULL
 			) ENGINE=InnoDB;
 
-			CREATE TABLE IF NOT EXISTS relationships (
-				id INT AUTO_INCREMENT PRIMARY KEY, 
-				from_id INT NOT NULL,
-				to_id INT NOT NULL,
-				type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
-				FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
-				FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
-			) ENGINE=InnoDB;
+                        CREATE TABLE IF NOT EXISTS relationships (
+                                id INT AUTO_INCREMENT PRIMARY KEY,
+                                from_id INT NOT NULL,
+                                to_id INT NOT NULL,
+                                type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
+                                FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
+                                FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
+                        ) ENGINE=InnoDB;
+
+                        CREATE TABLE IF NOT EXISTS requests (
+                                id INT AUTO_INCREMENT PRIMARY KEY,
+                                from_id INT NOT NULL,
+                                to_id INT NOT NULL,
+                                type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
+                                status ENUM('PENDING','ACCEPTED','REJECTED') DEFAULT 'PENDING',
+                                FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
+                                FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
+                        ) ENGINE=InnoDB;
 		");
 	} catch (PDOException $e) {
 		die("Database error: " . $e->getMessage());

--- a/mamp_demo/relationship.php
+++ b/mamp_demo/relationship.php
@@ -1,0 +1,47 @@
+<?php
+require 'config.php';
+if(!isset($_SESSION['user_id'])){ http_response_code(401); exit('Unauthorized'); }
+$action = $_POST['action'] ?? '';
+$user_id = $_SESSION['user_id'];
+
+switch($action){
+    case 'send_request':
+        $to_id = (int)($_POST['to_id'] ?? 0);
+        $type = $_POST['type'] ?? '';
+        if($to_id && $type){
+            $stmt = $pdo->prepare('INSERT INTO requests (from_id,to_id,type) VALUES (?,?,?)');
+            $stmt->execute([$user_id,$to_id,$type]);
+        }
+        break;
+    case 'modify_relationship':
+        $to_id = (int)($_POST['to_id'] ?? 0);
+        $type = $_POST['type'] ?? '';
+        if($to_id && $type){
+            $stmt = $pdo->prepare('UPDATE relationships SET type=? WHERE (from_id=? AND to_id=?) OR (from_id=? AND to_id=?)');
+            $stmt->execute([$type,$user_id,$to_id,$to_id,$user_id]);
+        }
+        break;
+    case 'remove_relationship':
+        $to_id = (int)($_POST['to_id'] ?? 0);
+        if($to_id){
+            $stmt = $pdo->prepare('DELETE FROM relationships WHERE (from_id=? AND to_id=?) OR (from_id=? AND to_id=?)');
+            $stmt->execute([$user_id,$to_id,$to_id,$user_id]);
+        }
+        break;
+    case 'accept_request':
+        $id = (int)($_POST['request_id'] ?? 0);
+        $stmt = $pdo->prepare('SELECT * FROM requests WHERE id=? AND to_id=? AND status="PENDING"');
+        $stmt->execute([$id,$user_id]);
+        if($req = $stmt->fetch()){
+            $pdo->prepare('UPDATE requests SET status="ACCEPTED" WHERE id=?')->execute([$id]);
+            $pdo->prepare('INSERT INTO relationships (from_id,to_id,type) VALUES (?,?,?)')->execute([$req['from_id'],$req['to_id'],$req['type']]);
+        }
+        break;
+    case 'reject_request':
+        $id = (int)($_POST['request_id'] ?? 0);
+        $pdo->prepare('UPDATE requests SET status="REJECTED" WHERE id=? AND to_id=?')->execute([$id,$user_id]);
+        break;
+    default:
+        exit('Unknown action');
+}
+header('Location: dashboard.php');


### PR DESCRIPTION
## Summary
- build relationship request table and handler
- show pending requests in bottom bar
- add menu for sending/updating/removing relationships

## Testing
- `php -l mamp_demo/config.php`
- `php -l mamp_demo/relationship.php`
- `php -l mamp_demo/dashboard.php`
- `php -l mamp_demo/index.php`
- `php -l mamp_demo/auth.php`
- `php -l mamp_demo/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68864f5c48b48326942a37fc50c9e19e