### PR TITLE
Improve PHP demo formatting and comments

### DIFF
--- a/mamp_demo/auth.php
+++ b/mamp_demo/auth.php
@@ -1,59 +1,56 @@
 <?php
-    require 'config.php';
-    $action = $_POST["action"] ?? "";
-    $username = trim($_POST["username"]) ?? "";
-    $password = $_POST["password"] ?? "";
-    if($action === "login")
-    {
-        $query = $pdo->prepare('SELECT id, password_hash FROM users WHERE username=?');
-        $query -> execute([$username]);
-        $user = $query->fetch();
-        if($user && password_verify($password, $user["password_hash"]))
-        {
-            // Store user information in the session
-            $_SESSION["user_id"] = $user["id"];
-            $_SESSION["username"] = $username;
-            header("Location: dashboard.php");exit;
-        }
-        header("Location: index.php?error=1");exit;
-    }
-    if($action === "register")
-    {
-        if(!$username || !$password)
-        {
-            exit("Missing field!");
-        }
-        
-        
-        $password_hash = password_hash($password, PASSWORD_DEFAULT);
+/**
+ * Handles user authentication and registration logic.
+ */
 
-        // Prepare SQL statement
-        $sql = 'INSERT INTO users (username, password_hash) VALUES (?, ?)';
-        $stmt = $pdo->prepare($sql);
+require 'config.php';
 
-        try 
-        {
-            // Execute query
-            $stmt->execute([$username, $password_hash]);
-        } 
-        catch (PDOException $e) 
-        {
-            if($e -> getCode() === "23000")
-            {
-                exit("Username exists");
-            }
-            throw $e;
-        }
-        header("Location: index.php?registered=1");exit;
+// Determine requested action
+$action   = $_POST['action']   ?? '';
+$username = trim($_POST['username'] ?? '');
+$password = $_POST['password'] ?? '';
 
+if ($action === 'login') {
+    // Attempt to log the user in
+    $query = $pdo->prepare('SELECT id, password_hash FROM users WHERE username = ?');
+    $query->execute([$username]);
+    $user = $query->fetch();
+
+    if ($user && password_verify($password, $user['password_hash'])) {
+        // Store user information in the session
+        $_SESSION['user_id']  = $user['id'];
+        $_SESSION['username'] = $username;
+        header('Location: dashboard.php');
+        exit;
     }
 
+    // Invalid credentials
+    header('Location: index.php?error=1');
+    exit;
+}
 
+if ($action === 'register') {
+    // Validate input fields
+    if (!$username || !$password) {
+        exit('Missing field!');
+    }
 
+    $password_hash = password_hash($password, PASSWORD_DEFAULT);
 
+    // Create new user record
+    $sql  = 'INSERT INTO users (username, password_hash) VALUES (?, ?)';
+    $stmt = $pdo->prepare($sql);
 
+    try {
+        $stmt->execute([$username, $password_hash]);
+    } catch (PDOException $e) {
+        if ($e->getCode() === '23000') {
+            exit('Username exists');
+        }
+        throw $e;
+    }
 
-
-
-
+    header('Location: index.php?registered=1');
+    exit;
+}
 

--- a/mamp_demo/config.php
+++ b/mamp_demo/config.php
@@ -1,53 +1,57 @@
 <?php
-	session_start();
-	
-	$host = 'localhost';
-	$root_user = 'root';
-	$root_password = 'root';
-	$db = 'social_demo';
-	$options = [
-		PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, 
-		PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
-	];
-	
-	try {
-		// Create connection without specifying database
-		$pdo = new PDO("mysql:host=$host;charset=utf8mb4", $root_user, $root_password, $options);
-		
-		// Create database if not exists
-		$pdo->exec("CREATE DATABASE IF NOT EXISTS `$db` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
-		
-		// Now connect to the specific database
-		$pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $root_user, $root_password, $options);
-		
-		// Create tables
-		$pdo->exec("
-			CREATE TABLE IF NOT EXISTS users (
-				id INT AUTO_INCREMENT PRIMARY KEY, 
-				username VARCHAR(50) UNIQUE NOT NULL,
-				password_hash VARCHAR(255) NOT NULL
-			) ENGINE=InnoDB;
+/**
+ * Application configuration and database initialization.
+ */
 
-                        CREATE TABLE IF NOT EXISTS relationships (
-                                id INT AUTO_INCREMENT PRIMARY KEY,
-                                from_id INT NOT NULL,
-                                to_id INT NOT NULL,
-                                type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
-                                FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
-                                FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
-                        ) ENGINE=InnoDB;
+session_start();
 
-                        CREATE TABLE IF NOT EXISTS requests (
-                                id INT AUTO_INCREMENT PRIMARY KEY,
-                                from_id INT NOT NULL,
-                                to_id INT NOT NULL,
-                                type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
-                                status ENUM('PENDING','ACCEPTED','REJECTED') DEFAULT 'PENDING',
-                                FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
-                                FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
-                        ) ENGINE=InnoDB;
-		");
-	} catch (PDOException $e) {
-		die("Database error: " . $e->getMessage());
-	}
-?>
+$host          = 'localhost';
+$root_user     = 'root';
+$root_password = 'root';
+$db            = 'social_demo';
+
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
+
+try {
+    // Connect without specifying database to create it if necessary
+    $pdo = new PDO("mysql:host=$host;charset=utf8mb4", $root_user, $root_password, $options);
+
+    // Create database if it doesn't exist
+    $pdo->exec("CREATE DATABASE IF NOT EXISTS `$db` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+    // Connect to the newly ensured database
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $root_user, $root_password, $options);
+
+    // Create required tables
+    $pdo->exec(
+        "CREATE TABLE IF NOT EXISTS users (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            username VARCHAR(50) UNIQUE NOT NULL,
+            password_hash VARCHAR(255) NOT NULL
+        ) ENGINE=InnoDB;
+
+        CREATE TABLE IF NOT EXISTS relationships (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            from_id INT NOT NULL,
+            to_id INT NOT NULL,
+            type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
+            FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB;
+
+        CREATE TABLE IF NOT EXISTS requests (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            from_id INT NOT NULL,
+            to_id INT NOT NULL,
+            type ENUM('DATING', 'BEST_FRIEND', 'BROTHER', 'SISTER', 'BEEFING', 'CRUSH') NOT NULL,
+            status ENUM('PENDING','ACCEPTED','REJECTED') DEFAULT 'PENDING',
+            FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB;"
+    );
+} catch (PDOException $e) {
+    die('Database error: ' . $e->getMessage());
+}

--- a/mamp_demo/dashboard.php
+++ b/mamp_demo/dashboard.php
@@ -1,19 +1,28 @@
 <?php
-    require "config.php";
+/**
+ * Main dashboard displaying the relationship graph.
+ */
 
-    if(!isset($_SESSION["user_id"]))
-    {
-        header("Location: index.php"); exit;
-    }
-    $nodes = $pdo->query('SELECT id, username FROM users')->fetchAll();
-    $edges = $pdo->query('SELECT from_id, to_id, type FROM relationships')->fetchAll();
-    $usernames = [];
-    foreach($nodes as $n){ $usernames[$n['id']] = $n['username']; }
-    $stmt = $pdo->prepare('SELECT r.id, r.from_id, r.type, u.username
-                           FROM requests r JOIN users u ON r.from_id=u.id
-                           WHERE r.to_id=? AND r.status="PENDING"');
-    $stmt->execute([$_SESSION['user_id']]);
-    $requests = $stmt->fetchAll();
+require 'config.php';
+
+// Redirect unauthenticated users
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+// Fetch graph nodes and edges
+$nodes = $pdo->query('SELECT id, username FROM users')->fetchAll();
+$edges = $pdo->query('SELECT from_id, to_id, type FROM relationships')->fetchAll();
+
+// Pending relationship requests for the current user
+$stmt = $pdo->prepare(
+    'SELECT r.id, r.from_id, r.type, u.username
+       FROM requests r JOIN users u ON r.from_id = u.id
+      WHERE r.to_id = ? AND r.status = "PENDING"'
+);
+$stmt->execute([$_SESSION['user_id']]);
+$requests = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/mamp_demo/index.php
+++ b/mamp_demo/index.php
@@ -1,9 +1,11 @@
 <?php
-    session_start();
-    if(isset($_SESSION["user_id"]))
-    {
-        header("Location: dashboard.php");exit;
-    }
+// Login/registration landing page
+session_start();
+if (isset($_SESSION['user_id'])) {
+    // Already logged in, redirect to dashboard
+    header('Location: dashboard.php');
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/mamp_demo/logout.php
+++ b/mamp_demo/logout.php
@@ -1,11 +1,13 @@
 <?php
-        session_start();
-        $_SESSION=[];
-	if(ini_get("session.use_cookies"))
-	{
-		$param = session_get_cookie_params();
-		setcookie(session_name(), "", time()-42000, $param["path"], $param["domain"], $param["secure"], $param["httponly"]);
-	}
-	session_destroy();
-	header("Location: index.php");exit;
-?>
+// Destroy the current session and redirect to the login page
+session_start();
+$_SESSION = [];
+
+if (ini_get('session.use_cookies')) {
+    $param = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $param['path'], $param['domain'], $param['secure'], $param['httponly']);
+}
+
+session_destroy();
+header('Location: index.php');
+exit;

--- a/mamp_demo/relationship.php
+++ b/mamp_demo/relationship.php
@@ -1,47 +1,63 @@
 <?php
+/**
+ * Handles modifications to relationship data via POST requests.
+ */
+
 require 'config.php';
-if(!isset($_SESSION['user_id'])){ http_response_code(401); exit('Unauthorized'); }
-$action = $_POST['action'] ?? '';
+
+// Ensure the user is authenticated
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    exit('Unauthorized');
+}
+
+$action  = $_POST['action'] ?? '';
 $user_id = $_SESSION['user_id'];
 
 switch($action){
     case 'send_request':
+        // Create a new relationship request
         $to_id = (int)($_POST['to_id'] ?? 0);
-        $type = $_POST['type'] ?? '';
-        if($to_id && $type){
+        $type  = $_POST['type'] ?? '';
+        if ($to_id && $type) {
             $stmt = $pdo->prepare('INSERT INTO requests (from_id,to_id,type) VALUES (?,?,?)');
-            $stmt->execute([$user_id,$to_id,$type]);
+            $stmt->execute([$user_id, $to_id, $type]);
         }
         break;
     case 'modify_relationship':
+        // Update an existing relationship
         $to_id = (int)($_POST['to_id'] ?? 0);
-        $type = $_POST['type'] ?? '';
-        if($to_id && $type){
+        $type  = $_POST['type'] ?? '';
+        if ($to_id && $type) {
             $stmt = $pdo->prepare('UPDATE relationships SET type=? WHERE (from_id=? AND to_id=?) OR (from_id=? AND to_id=?)');
-            $stmt->execute([$type,$user_id,$to_id,$to_id,$user_id]);
+            $stmt->execute([$type, $user_id, $to_id, $to_id, $user_id]);
         }
         break;
     case 'remove_relationship':
+        // Delete a relationship
         $to_id = (int)($_POST['to_id'] ?? 0);
-        if($to_id){
+        if ($to_id) {
             $stmt = $pdo->prepare('DELETE FROM relationships WHERE (from_id=? AND to_id=?) OR (from_id=? AND to_id=?)');
-            $stmt->execute([$user_id,$to_id,$to_id,$user_id]);
+            $stmt->execute([$user_id, $to_id, $to_id, $user_id]);
         }
         break;
     case 'accept_request':
-        $id = (int)($_POST['request_id'] ?? 0);
+        // Accept an incoming relationship request
+        $id   = (int)($_POST['request_id'] ?? 0);
         $stmt = $pdo->prepare('SELECT * FROM requests WHERE id=? AND to_id=? AND status="PENDING"');
-        $stmt->execute([$id,$user_id]);
-        if($req = $stmt->fetch()){
+        $stmt->execute([$id, $user_id]);
+        if ($req = $stmt->fetch()) {
             $pdo->prepare('UPDATE requests SET status="ACCEPTED" WHERE id=?')->execute([$id]);
-            $pdo->prepare('INSERT INTO relationships (from_id,to_id,type) VALUES (?,?,?)')->execute([$req['from_id'],$req['to_id'],$req['type']]);
+            $pdo->prepare('INSERT INTO relationships (from_id,to_id,type) VALUES (?,?,?)')->execute([$req['from_id'], $req['to_id'], $req['type']]);
         }
         break;
     case 'reject_request':
+        // Reject a request
         $id = (int)($_POST['request_id'] ?? 0);
-        $pdo->prepare('UPDATE requests SET status="REJECTED" WHERE id=? AND to_id=?')->execute([$id,$user_id]);
+        $pdo->prepare('UPDATE requests SET status="REJECTED" WHERE id=? AND to_id=?')->execute([$id, $user_id]);
         break;
     default:
         exit('Unknown action');
 }
 header('Location: dashboard.php');
+


### PR DESCRIPTION
## Summary
- restyle PHP scripts and add explanatory comments
- normalize whitespace and newline endings
- clean up trailing blank lines

## Testing
- `php -l mamp_demo/auth.php`
- `php -l mamp_demo/config.php`
- `php -l mamp_demo/dashboard.php`
- `php -l mamp_demo/index.php`
- `php -l mamp_demo/logout.php`
- `php -l mamp_demo/relationship.php`


------
https://chatgpt.com/codex/tasks/task_e_6886fee1aec883268af252590032b6ef