### PR TITLE
Support multiple chat tabs, slim bottom bar, and modernized top bar

### DIFF
--- a/mamp_demo/config.php
+++ b/mamp_demo/config.php
@@ -50,6 +50,17 @@ try {
             status ENUM('PENDING','ACCEPTED','REJECTED') DEFAULT 'PENDING',
             FOREIGN KEY (from_id) REFERENCES users(id) ON DELETE CASCADE,
             FOREIGN KEY (to_id) REFERENCES users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB;
+
+        /* Direct messages between related users */
+        CREATE TABLE IF NOT EXISTS messages (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            sender_id INT NOT NULL,
+            receiver_id INT NOT NULL,
+            message TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (sender_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (receiver_id) REFERENCES users(id) ON DELETE CASCADE
         ) ENGINE=InnoDB;"
     );
 } catch (PDOException $e) {

--- a/mamp_demo/dashboard.php
+++ b/mamp_demo/dashboard.php
@@ -35,11 +35,47 @@ $requests = $stmt->fetchAll();
     <style>
         body            { font-family: system-ui, sans-serif; background-color: lightgreen; }
         html, body      { margin:0; padding:0; height:100%; overflow:hidden; }
-        #graph          { width:100vw; height:calc(100vh - 110px); border:none; }
-        #top_bar        { background:lightyellow; padding:.5rem 1rem; height:30px; }
-        #search_bar     { padding:.25rem 1rem; background:#fff; }
-        #search_input   { width:200px; }
-        #bottom_bar     { background:lightyellow; min-height:40px; padding:.5rem 1rem; }
+        /* Network graph fills the viewport minus the header and footer */
+        #graph          { width:100vw; height:calc(100vh - 100px); border:none; }
+
+        /* Polished top bar greeting/search/logout section */
+        #top_bar{
+            background:#fff;
+            border-bottom:1px solid #ccc;
+            box-shadow:0 2px 4px rgba(0,0,0,0.05);
+            display:flex;
+            justify-content:space-between;
+            align-items:center;
+            padding:0.5rem 1rem;
+            height:50px;
+        }
+        #top_bar .left{ display:flex; align-items:center; gap:1rem; }
+        #search_input{ padding:.25rem .5rem; border:1px solid #ccc; border-radius:4px; }
+        #search_btn{ padding:.25rem .75rem; margin-left:.25rem; }
+        #logout_link{ color:#06c; text-decoration:none; font-weight:500; }
+        #logout_link:hover{ text-decoration:underline; }
+
+        /* Bottom bar mirrors the top bar styling */
+        #bottom_bar{
+            background:#fff;
+            border-top:1px solid #ccc;
+            box-shadow:0 -2px 4px rgba(0,0,0,0.05);
+            position:fixed;
+            bottom:0;
+            width:100%;
+            display:flex;
+            justify-content:space-between;
+            align-items:center;
+            padding:0.5rem 1rem;
+            height:50px;
+        }
+
+        /* Scrollable container for chat tabs */
+        #chat_tabs      { display:flex; gap:6px; max-width:60%; overflow-x:auto; }
+
+        /* Individual chat tab with close button */
+        .chat_tab       { background:#fff; border:1px solid #ccc; border-radius:4px; padding:0 4px; cursor:pointer; white-space:nowrap; display:flex; align-items:center; }
+        .chat_tab button{ margin-left:4px; }
         .context-menu   {
             position:absolute; background:#ffffffee; box-shadow:0 2px 6px rgba(0,0,0,.2);
             border-radius:4px; padding:.5rem; display:none; z-index:10;
@@ -48,23 +84,35 @@ $requests = $stmt->fetchAll();
             display:block; width:100%; background:none; border:none;
             padding:.25rem 0; cursor:pointer; text-align:left;
         }
+        /* Floating chat window anchored above the bottom bar */
+        #chat_bubble   { display:none; border:1px solid #333; background:#fff; padding:.5rem; max-width:300px; position:fixed; right:0; bottom:0; }
+
+        /* Scrollable area containing message history */
+        #chat_messages { height:150px; overflow-y:auto; margin-bottom:.5rem; background:#fefefe; }
+
+        /* Chat input aligned beside Send button */
+        #chat_form     { display:flex; gap:4px; }
+        #chat_input    { flex:1; }
     </style>
 </head>
 <body>
     <div id="top_bar">
-        Hello, <?php echo htmlspecialchars($_SESSION["username"]);?>
-        <a style="float:right" href="logout.php">Log Out</a>
-    </div>
-
-    <div id="search_bar">
-        <input type="text" id="search_input" placeholder="Search user.">
-        <button id="search_btn">Go</button>
+        <div class="left">
+            <span>Hello, <?php echo htmlspecialchars($_SESSION["username"]);?></span>
+            <div class="search">
+                <input type="text" id="search_input" placeholder="Search user">
+                <button id="search_btn">Go</button>
+            </div>
+        </div>
+        <a id="logout_link" href="logout.php">Log Out</a>
     </div>
 
     <div id="graph"></div>
     <div id="contextMenu" class="context-menu"></div>
 
+    <!-- Fixed footer with relationship requests and chat tabs -->
     <div id="bottom_bar">
+        <div id="request_area">
         <?php if($requests): foreach($requests as $r): ?>
             <div style="margin-bottom:4px;">
                 <?=htmlspecialchars($r['username'])?> requests <?=htmlspecialchars($r['type'])?>
@@ -82,6 +130,17 @@ $requests = $stmt->fetchAll();
         <?php endforeach; else: ?>
             Ready
         <?php endif; ?>
+        </div>
+        <div id="chat_tabs"></div>
+    </div>
+
+    <!-- Floating chat bubble that displays the active conversation -->
+    <div id="chat_bubble">
+        <div id="chat_messages"></div>
+        <form id="chat_form">
+            <input type="text" id="chat_input" autocomplete="off">
+            <button type="submit">Send</button>
+        </form>
     </div>
 
     <script>
@@ -169,6 +228,114 @@ $requests = $stmt->fetchAll();
                 post('remove_relationship', {to_id:id});
         }
 
+        // ----- Direct messaging helpers -----
+        let activeChat = null;                                 // ID of the user currently being chatted with
+        let lastMessageId = 0;                                 // Highest message ID seen so far
+        const bubble = document.getElementById('chat_bubble'); // Floating chat window element
+        const messagesDiv = document.getElementById('chat_messages');
+        const tabsDiv = document.getElementById('chat_tabs');  // Container that holds chat tabs
+        const tabs = {};                                      // Map of user_id -> tab element
+        const bottomBar = document.getElementById('bottom_bar');
+
+        // Ask server for the most recent message ID to avoid opening old chats on load
+        function initLatest(){
+            fetch('dm.php?action=latest_id')
+                .then(r=>r.json())
+                .then(d=>{ if(d && d.latest) lastMessageId = d.latest; });
+        }
+        initLatest();
+
+        // Keep the chat bubble positioned just above the bottom bar
+        function positionBubble(){
+            bubble.style.right = '0';
+            bubble.style.bottom = bottomBar.offsetHeight + 'px';
+        }
+        window.addEventListener('resize', positionBubble);
+
+        // Ensure a tab exists for the given user ID and return it
+        function ensureTab(id){
+            if(tabs[id]) return tabs[id];
+            const span = document.createElement('span');
+            span.className = 'chat_tab';
+            span.textContent = 'Chat with ' + nodes.get(id).label;
+            span.addEventListener('click', () => openChat(id));
+            const btn = document.createElement('button');
+            btn.textContent = 'x';
+            btn.addEventListener('click', e => { e.stopPropagation(); closeChat(id); });
+            span.appendChild(btn);
+            tabsDiv.appendChild(span);
+            tabs[id] = span;
+            positionBubble();
+            return span;
+        }
+
+        // Display the chat bubble and load history for a given user
+        function openChat(id){
+            ensureTab(id);
+            activeChat = id;
+            bubble.style.display = 'block';
+            positionBubble();
+            loadMessages();
+        }
+
+        // Close the tab and hide the bubble if the active chat is closed
+        function closeChat(id){
+            if(tabs[id]){ tabs[id].remove(); delete tabs[id]; positionBubble(); }
+            if(activeChat === id){
+                activeChat = null;
+                bubble.style.display = 'none';
+            }
+        }
+
+        // Fetch the full conversation with the active chat partner
+        function loadMessages(){
+            if(activeChat === null) return;
+            fetch('dm.php?action=fetch&user_id='+activeChat)
+                .then(r=>r.json())
+                .then(msgs=>{
+                    messagesDiv.innerHTML = msgs.map(m=>`<div><strong>${m.sender_id==user_id?'Me':nodes.get(m.sender_id).label}:</strong> ${m.message}</div>`).join('');
+                    if(msgs.length) lastMessageId = msgs[msgs.length-1].id;
+                    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+                });
+        }
+
+        // Poll for new messages and open tabs as senders arrive
+        function checkIncoming(){
+            fetch('dm.php?action=latest&since='+lastMessageId)
+                .then(r=>r.json())
+                .then(arr=>{
+                    if(!Array.isArray(arr) || !arr.length) return;
+                    let reload = false;
+                    arr.forEach(m=>{
+                        if(m.id>lastMessageId) lastMessageId = m.id;
+                        ensureTab(m.sender_id);
+                        if(activeChat === m.sender_id) reload = true;
+                    });
+                    if(activeChat===null) openChat(arr[arr.length-1].sender_id);
+                    else if(reload) loadMessages();
+                });
+        }
+
+        // Regularly refresh the active conversation and check for new messages
+        setInterval(loadMessages,3000);
+        setInterval(checkIncoming,3000);
+
+        // Send a message when the chat form is submitted
+        document.getElementById('chat_form').addEventListener('submit', e=>{
+            e.preventDefault();
+            if(activeChat===null) return;
+            const text = document.getElementById('chat_input').value.trim();
+            if(!text) return;
+            fetch('dm.php', {
+                method:'POST',
+                headers:{'Content-Type':'application/x-www-form-urlencoded'},
+                body:new URLSearchParams({action:'send', user_id:activeChat, message:text})
+            }).then(()=>{
+                document.getElementById('chat_input').value='';
+                loadMessages();
+            });
+        });
+
         network.on('click', params => {
             if(params.nodes.length){
                 const id = params.nodes[0];
@@ -189,6 +356,7 @@ $requests = $stmt->fetchAll();
 
                 if(hasRel){
                     menu.innerHTML =
+                        '<button onclick="openChat('+id+')">Message</button><br>'+
                         optionSelect(id,'modType')+
                         '<button onclick="modifyRelationship('+id+')">Modify</button><br>'+
                         '<button onclick="removeRelationship('+id+')">Remove Relationship</button>';

--- a/mamp_demo/dm.php
+++ b/mamp_demo/dm.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Simple direct messaging endpoint.
+ * Actions determined by the `action` parameter:
+ *   - fetch: full conversation with a specific user
+ *   - latest_id: highest message ID received so far
+ *   - latest: messages newer than a given ID
+ *   - send: store a new outgoing message
+ */
+require 'config.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    exit;
+}
+
+$user_id = (int)$_SESSION['user_id'];
+$action  = $_REQUEST['action'] ?? '';
+
+// Verify that two users have an established relationship before messaging
+function hasRelationship(PDO $pdo, int $a, int $b): bool {
+    $stmt = $pdo->prepare('SELECT 1 FROM relationships WHERE (from_id=? AND to_id=?) OR (from_id=? AND to_id=?)');
+    $stmt->execute([$a,$b,$b,$a]);
+    return (bool)$stmt->fetchColumn();
+}
+
+// Return the full message history with a particular user
+if ($action === 'fetch') {
+    $other_id = (int)($_GET['user_id'] ?? 0);
+    if (!$other_id || !hasRelationship($pdo, $user_id, $other_id)) {
+        http_response_code(403);
+        exit;
+    }
+    $stmt = $pdo->prepare(
+        'SELECT id, sender_id, message, DATE_FORMAT(created_at, "%Y-%m-%d %H:%i:%s") AS created_at\n'
+       .' FROM messages\n'
+       .' WHERE (sender_id=? AND receiver_id=?) OR (sender_id=? AND receiver_id=?)\n'
+       .' ORDER BY id ASC'
+    );
+    $stmt->execute([$user_id,$other_id,$other_id,$user_id]);
+    header('Content-Type: application/json');
+    echo json_encode($stmt->fetchAll());
+    exit;
+}
+
+// Return the highest message ID the user has received (used on login)
+if ($action === 'latest_id') {
+    $stmt = $pdo->prepare('SELECT MAX(id) FROM messages WHERE receiver_id=?');
+    $stmt->execute([$user_id]);
+    header('Content-Type: application/json');
+    echo json_encode(['latest' => (int)$stmt->fetchColumn()]);
+    exit;
+}
+
+// Fetch all messages newer than the provided ID
+if ($action === 'latest') {
+    $since = (int)($_GET['since'] ?? 0);
+    $stmt = $pdo->prepare(
+        'SELECT id, sender_id, message\n'
+       .' FROM messages\n'
+       .' WHERE receiver_id=? AND id>?\n'
+       .' ORDER BY id ASC'
+    );
+    $stmt->execute([$user_id, $since]);
+    header('Content-Type: application/json');
+    echo json_encode($stmt->fetchAll());
+    exit;
+}
+
+// Store a new message addressed to another user
+if ($action === 'send') {
+    $other_id = (int)($_POST['user_id'] ?? 0);
+    $msg = trim($_POST['message'] ?? '');
+    if (!$other_id || $msg === '' || !hasRelationship($pdo, $user_id, $other_id)) {
+        http_response_code(400);
+        exit;
+    }
+    $stmt = $pdo->prepare('INSERT INTO messages (sender_id, receiver_id, message) VALUES (?,?,?)');
+    $stmt->execute([$user_id,$other_id,$msg]);
+    echo 'OK';
+    exit;
+}
+
+http_response_code(400);
+?>


### PR DESCRIPTION
## Summary
- Shrink bottom bar padding and show each conversation as a tab with its own close button
- Poll for all new messages and create tabs for each sender so multiple DMs surface at once
- Position chat bubble flush to the bottom bar without extra gaps
- Consolidate greeting, search, and logout into a polished top bar with modern styling
- Remove extra right-side gap from the chat input line with a flex layout
- Track the latest DM ID at login so only new messages open tabs automatically
- Make bottom bar visually consistent with top bar styling
- Add detailed inline comments explaining the DM system and dashboard helpers

## Testing
- `php -l mamp_demo/config.php`
- `php -l mamp_demo/dm.php`
- `php -l mamp_demo/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68b309778bb883268d1c589d82c97bc3